### PR TITLE
raise InvalidMoveError if dspy failes to parse

### DIFF
--- a/zero_sum_eval/core/__init__.py
+++ b/zero_sum_eval/core/__init__.py
@@ -1,0 +1,2 @@
+class InvalidMoveError(Exception):
+    pass

--- a/zero_sum_eval/core/__init__.py
+++ b/zero_sum_eval/core/__init__.py
@@ -1,2 +1,0 @@
-class InvalidMoveError(Exception):
-    pass

--- a/zero_sum_eval/core/game_state.py
+++ b/zero_sum_eval/core/game_state.py
@@ -10,15 +10,13 @@ from typing import Dict, List
 
 from zero_sum_eval.utils.types import ActionConfig, Action
 from zero_sum_eval.core.player import Move, PlayerDefinition
-
+from zero_sum_eval.core import InvalidMoveError
 # Get the package version
 try:
     __version__ = importlib.metadata.version("zero_sum_eval")
 except importlib.metadata.PackageNotFoundError:
     __version__ = "unknown"
 
-class InvalidMoveError(Exception):
-    pass
 
 
 class GameState(ABC):

--- a/zero_sum_eval/core/game_state.py
+++ b/zero_sum_eval/core/game_state.py
@@ -8,9 +8,8 @@ from copy import copy
 import time
 from typing import Dict, List
 
-from zero_sum_eval.utils.types import ActionConfig, Action
+from zero_sum_eval.utils.types import ActionConfig, Action, InvalidMoveError
 from zero_sum_eval.core.player import Move, PlayerDefinition
-from zero_sum_eval.core import InvalidMoveError
 # Get the package version
 try:
     __version__ = importlib.metadata.version("zero_sum_eval")

--- a/zero_sum_eval/core/player.py
+++ b/zero_sum_eval/core/player.py
@@ -8,7 +8,7 @@ import time
 from dspy.primitives import assert_transform_module, backtrack_handler
 from zero_sum_eval.utils.checkpointing import save_checkpoint, load_checkpoint, get_cached_module_path
 from zero_sum_eval.utils.types import Action, ActionConfig, Move
-from zero_sum_eval.core.game_state import InvalidMoveError
+from zero_sum_eval.core import InvalidMoveError
 
 # Disable debugging logs of litellm
 import litellm

--- a/zero_sum_eval/core/player.py
+++ b/zero_sum_eval/core/player.py
@@ -8,6 +8,7 @@ import time
 from dspy.primitives import assert_transform_module, backtrack_handler
 from zero_sum_eval.utils.checkpointing import save_checkpoint, load_checkpoint, get_cached_module_path
 from zero_sum_eval.utils.types import Action, ActionConfig, Move
+from zero_sum_eval.core.game_state import InvalidMoveError
 
 # Disable debugging logs of litellm
 import litellm
@@ -134,10 +135,13 @@ class Player(ABC):
     def act(self, action: Action) -> Move:
         if isinstance(self.action_fn_dict[action.name], dspy.Module):
             start_time = time.time()
-            with dspy.context(lm=self.llm_model):
-                trace = self.action_fn_dict[action.name](**action.inputs)
-            output = trace.items()[-1][1]
-            return Move(value=output, time=time.time() - start_time, trace=trace)
+            try:
+                with dspy.context(lm=self.llm_model):
+                    trace = self.action_fn_dict[action.name](**action.inputs)
+                output = trace.items()[-1][1]
+                return Move(value=output, time=time.time() - start_time, trace=trace)
+            except ValueError as e:
+                raise InvalidMoveError(f"Error producing move for action {action.name}: {e}") from e
         else:
             start_time = time.time()
             output = self.action_fn_dict[action.name](**action.inputs)

--- a/zero_sum_eval/core/player.py
+++ b/zero_sum_eval/core/player.py
@@ -7,8 +7,7 @@ import dspy
 import time
 from dspy.primitives import assert_transform_module, backtrack_handler
 from zero_sum_eval.utils.checkpointing import save_checkpoint, load_checkpoint, get_cached_module_path
-from zero_sum_eval.utils.types import Action, ActionConfig, Move
-from zero_sum_eval.core import InvalidMoveError
+from zero_sum_eval.utils.types import Action, ActionConfig, Move, MoveParseError
 
 # Disable debugging logs of litellm
 import litellm
@@ -141,7 +140,8 @@ class Player(ABC):
                 output = trace.items()[-1][1]
                 return Move(value=output, time=time.time() - start_time, trace=trace)
             except ValueError as e:
-                raise InvalidMoveError(f"Error producing move for action {action.name}: {e}") from e
+                # TODO: remove this once dspy figures out better parsing
+                raise MoveParseError(f"Error producing move for action {action.name}: {e}") from e
         else:
             start_time = time.time()
             output = self.action_fn_dict[action.name](**action.inputs)

--- a/zero_sum_eval/managers/game_manager.py
+++ b/zero_sum_eval/managers/game_manager.py
@@ -8,7 +8,8 @@ from typing import Dict, List
 
 import jsonlines
 
-from zero_sum_eval.core.game_state import GameState, InvalidMoveError, MoveParseError
+from zero_sum_eval.core.game_state import GameState
+from zero_sum_eval.utils.types import InvalidMoveError, MoveParseError
 from zero_sum_eval.core.player import Player
 
 class GameManager:

--- a/zero_sum_eval/managers/game_manager.py
+++ b/zero_sum_eval/managers/game_manager.py
@@ -8,7 +8,7 @@ from typing import Dict, List
 
 import jsonlines
 
-from zero_sum_eval.core.game_state import GameState, InvalidMoveError
+from zero_sum_eval.core.game_state import GameState, InvalidMoveError, MoveParseError
 from zero_sum_eval.core.player import Player
 
 class GameManager:
@@ -70,9 +70,12 @@ class GameManager:
                 game_state.update_game(move)
                 retrying = False
                 logger.info(f"\nPlayer {player.id} made move:\n{move.value}\n\n")
-            except InvalidMoveError as e:
+            except (InvalidMoveError, MoveParseError) as e:
                 # If the move was invalid, log the error and increment the player's attempts
-                logger.error(f"Invalid move: {e}")
+                if isinstance(e, InvalidMoveError):
+                    logger.error(f"Invalid move: {e}")
+                else:
+                    logger.error(f"Move parse error: {e}")
                 self.player_attempts[player] += 1
                 retrying = True
                 if self.player_attempts[player] >= self.max_player_attempts:

--- a/zero_sum_eval/managers/game_manager.py
+++ b/zero_sum_eval/managers/game_manager.py
@@ -55,20 +55,18 @@ class GameManager:
             logger.info(f"\t\t--- {player.id} (attempt # {self.player_attempts[player]}) ---")
             logger.info(f"Game State:\n{game_state.display()}\n")
 
-            move = player.act(action)
-            
-            # Update the player's time usage
-            self.player_time_used[player] += move.time
-            
-            # Check if player has exceeded their time limit
-            if self.max_time_per_player is not None and self.player_time_used[player] > self.max_time_per_player:
-                logger.info(f"Player {player.id} has exceeded the maximum time limit of {self.max_time_per_player} seconds. Ending game.")
-                game_state.set_timeout_loss(player.id)
-                break
-                
-            logger.info(f"Move took {move.time:.2f} seconds. Total time used by {player.id}: {self.player_time_used[player]:.2f} seconds")
-            
             try:
+                move = player.act(action)
+                # Update the player's time usage
+                self.player_time_used[player] += move.time
+                
+                # Check if player has exceeded their time limit
+                if self.max_time_per_player is not None and self.player_time_used[player] > self.max_time_per_player:
+                    logger.info(f"Player {player.id} has exceeded the maximum time limit of {self.max_time_per_player} seconds. Ending game.")
+                    game_state.set_timeout_loss(player.id)
+                    break
+                    
+                logger.info(f"Move took {move.time:.2f} seconds. Total time used by {player.id}: {self.player_time_used[player]:.2f} seconds")
                 game_state.update_game(move)
                 retrying = False
                 logger.info(f"\nPlayer {player.id} made move:\n{move.value}\n\n")

--- a/zero_sum_eval/utils/types.py
+++ b/zero_sum_eval/utils/types.py
@@ -43,3 +43,9 @@ class Dataset(ABC):
     @abstractmethod
     def get_dataset(self) -> Iterable[Example]:
         pass
+
+class InvalidMoveError(Exception):
+    pass
+
+class MoveParseError(Exception):
+    pass


### PR DESCRIPTION
added a check in player to catch dspy parsing errors and raise InvalidMoveError so that games can proceed if the model fails to follow dspy format provided in its instructions.